### PR TITLE
hotfix-gitworkflow: docker-image.yml 깃헙 액션 워크플로 파일 변경 핫픽스

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -28,13 +28,13 @@ jobs:
         run: echo "IMAGE_NAME=choseongwoo/ganoverflow-back:$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
 
       - name: Build and push Docker image
-        run: |
-          cd nest 
-          docker build -t ${{ env.IMAGE_NAME }} . 
-          docker push ${{ env.IMAGE_NAME }}
-          cd ../
+        uses: docker/build-push-action@v2
         with:
-          command_timeout: 200m
+          context: ./nest
+          push: true
+          tags: ${{ env.IMAGE_NAME }}
+          timeout: 12000
+
 
       # - name: Modify docker-compose.yml
       #   run: |


### PR DESCRIPTION
 uses 사용 없이 with로 command_timeout을 주어 스크립트 액션 집행에 에러를 발생시켰습니다.
 
 깃허브 액션 워크플로 파일에 with command_timeout 부여했던 'Build and push Docker image' 태스크를 uses를 사용하도록 수정하여 command_timeout을 유효하도록 수정했습니다. 
 
이는 기존 액션배포 과정 수행 시 간헐적으로 해당 태스크에서 10분 이상이 걸려 default timeout을 초과하는 케이스를 확인하였기에 취한 조치입니다.