### PR TITLE
hotfix-gitworkflow: Build and push Docker image에서 with command_timeout을 제거, uses 대신 run으로 복구 -> 배포 복구

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -28,16 +28,11 @@ jobs:
         run: echo "IMAGE_NAME=choseongwoo/ganoverflow-back:$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: ./nest
-          push: true
-          tags: ${{ env.IMAGE_NAME }}
-          timeout: 12000
-
-
-      # - name: Modify docker-compose.yml
-      #   run: |
+        run: |
+          cd nest 
+          docker build -t ${{ env.IMAGE_NAME }} . 
+          docker push ${{ env.IMAGE_NAME }}
+          cd ../
 
       - name: SSH Remote Commands
         uses: appleboy/ssh-action@v0.1.10


### PR DESCRIPTION
배포 상 문제가 발생하여 hotfix합니다.
추후 command_timeout을 해당 태스크에 적용시킬 고민을 해보아야 할 것 같습니다.