### PR TITLE
feat-auth: AuthGuard의 예외 추가를 통한 preflight request CORS 방지

### DIFF
--- a/nest/src/auth/auth.guard.ts
+++ b/nest/src/auth/auth.guard.ts
@@ -22,11 +22,18 @@ export class AuthGuard implements CanActivate {
       context.getHandler(),
       context.getClass(),
     ]);
+
+    // 예외1: @Public 데코레이터 붙인 케이스
     if (isPublic) {
       return true;
     }
 
+    // 예외2: OPTIONS 메서드로 Preflight인 경우
     const request = context.switchToHttp().getRequest();
+    if (request.method === "OPTIONS") {
+      return true;
+    }
+
     const token = this.extractTokenFromHeader(request);
 
     if (!token) {


### PR DESCRIPTION
CORS 에러 확인 및 문제 진단 후 조치하였습니다.

`app.module.ts`파일에서 allow origin을 설정해주었음에도 불구하고, CORS가 발생하였기에
가장 최근 적용한 AuthGuard가 전역처리 된 것이 문제라는 사실을 확인할 수 있었습니다.

AuthGuard는 CORS Preflight 요청 또한 차단할 수 있다는 문제에 기인합니다.


따라서 현재 AuthGuard는 아래 두가지 케이스로 예외를 적용합니다.

```auth.guard.ts
    // 예외1: @Public 데코레이터 붙인 케이스
    if (isPublic) {
      return true;
    }

    // 예외2: OPTIONS 메서드로 Preflight인 경우
    const request = context.switchToHttp().getRequest();
    if (request.method === "OPTIONS") {
      return true;
    }
```