### PR TITLE
chore-envVars: 환경변수 관리 (configService 사용) 및 Docker를 통한 주입 방식 변경 관련 작업 수행

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 /dist
 
+.env.*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "1"
 services:
   nest:
-    image: choseongwoo/ganoverflow-back:v0626-1
+    image: choseongwoo/ganoverflow-back:v0705-envmod-test
     container_name: nest
     #volumes:
     #  - ./src:/app/src
@@ -12,6 +12,8 @@ services:
       - app-network
     depends_on:
       - db
+    env_file:
+      - .env.production
   nginx:
     container_name: nginx-nest
     image: nginx:1.19.0-alpine

--- a/nest/.gitignore
+++ b/nest/.gitignore
@@ -36,5 +36,3 @@ lerna-debug.log*
 
 # env파일 제외
 .env.*
-.env.dev
-.env.prod

--- a/nest/src/app.module.ts
+++ b/nest/src/app.module.ts
@@ -28,15 +28,19 @@ import { ChatPairsModule } from "./chat-pairs/chat-pairs.module";
           : ".env.production",
     }),
 
-    TypeOrmModule.forRoot({
-      type: "postgres",
-      host: process.env.DB_HOST,
-      port: +process.env.DB_PORT,
-      username: process.env.DB_USERNAME,
-      password: process.env.DB_PASSWORD,
-      database: process.env.DB_NAME,
-      entities: [__dirname + "/**/*.entity{.ts,.js}"],
-      synchronize: true,
+    TypeOrmModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        type: "postgres",
+        host: configService.get("DB_HOST"),
+        port: +configService.get("DB_PORT"),
+        username: configService.get("DB_USERNAME"),
+        password: configService.get("DB_PASSWORD"),
+        database: configService.get("DB_NAME"),
+        entities: [__dirname + "/**/*.entity{.ts,.js}"],
+        synchronize: true,
+      }),
     }),
     UserModule,
     AuthModule,

--- a/nest/src/auth/auth.service.ts
+++ b/nest/src/auth/auth.service.ts
@@ -4,12 +4,13 @@ import { LoginUserDto } from "src/user/dto/login-user.dto";
 import { User } from "src/user/entities/user.entity";
 import { UserService } from "src/user/user.service";
 import { jwtConstants } from "./constants";
-
+import { ConfigService } from "@nestjs/config";
 @Injectable()
 export class AuthService {
   constructor(
     private userService: UserService,
-    private jwtService: JwtService
+    private jwtService: JwtService,
+    private configService: ConfigService
   ) {}
 
   async login(loginUserDto: LoginUserDto) {
@@ -52,9 +53,10 @@ export class AuthService {
   }
 
   async setCookieWithRefreshToken(res: any, refresh_token: string) {
+    const cookieSecure = this.configService.get("COOKIE_SECURE") === "true"; // env파일 별 분기 string -> boolean 변환이요!
     res.cookie("refresh_token", refresh_token, {
-      httpOnly: process.env.COOKIE_SECURE !== "false",
-      secure: process.env.COOKIE_SECURE !== "false",
+      httpOnly: cookieSecure,
+      secure: cookieSecure,
       maxAge: 1000 * 60 * 60 * 24 * 7,
     });
 


### PR DESCRIPTION
# 1. docker-compose 시점에서 환경변수 주입하도록 변경
기존의 환경변수 관리 방식은 env파일을 github에 공개하여 배포 자동화 수행 중 github action에서 Dockerfile을 통해 이미지를 빌드할 때 이 파일을 컨테이너 내부에 삽입하도록 관리해왔습니다.

하지만, github에 해당 env파일을 노출하는 것은 치명적인 보안취약점이므로 개선이 필요하여 하기의 작업을 수행했습니다.

환경변수는 빌드 시점이 아닌 런타임 중 주입 된다는 사실을 알게 되었습니다.
이에 따라, docker-compose.yml파일에 env파일을 참조하는 설정을 더해주었고, 간단하게 서버 상 docker-compose.yml파일과 같은 경로에 .env.production 복사본 파일을 붙여넣는 작업을 수행하여, production 모드로 nest 컨테이너를 구동하도록 설정된 docker-compose.yml이 해당 서버 내 환경변수 파일을 주입하도록 하였습니다.

# 2. dotenv 기반 환경변수 참조 -> configService를 사용한 nest전용 환경변수 관리 방식으로 전환 

## 2.1. 루트 및 서브에 configServce 사용 방식으로 설정 통일
app.module.ts: 환경변수를 `TypeOrmModule.forRootAsync` 루트 설정에서 configService를 주입하여 사용할 수 있도록 변경했습니다.
 - 따라서 앞으로는 서브앱의 서비스 클래스의 생성자에 configService만 설정해주면, `this.config.service.get('환경변수명')`을 가져와 사용할 수 있습니다. (`auth.service.ts` 파일에 적용한 변경사항 참고)

## 2.2. 서버 구동 환경 (dev/prod) 로그 출력 처리 및 시점 변경
기존 dotenv를 통해 bootstrap() 이전에 서버환경을 출력하도록 했던 것을, configService 방식으로 통일함에 따라, main.ts에서 bootStrap 내 NestFactory 생성 평가 이후, configService를 통해 판별된 서버구동 환경 분기 로그 출력을 처리하도록 변경하였습니다.