### PR TITLE
0705: feat-auth: 배포 클라/서버 간 쿠키의 정상적 송수신을 위한 cookie set 설정 추가 (domain, ...samesite) 

### DIFF
--- a/nest/src/auth/auth.service.ts
+++ b/nest/src/auth/auth.service.ts
@@ -54,9 +54,13 @@ export class AuthService {
 
   async setCookieWithRefreshToken(res: any, refresh_token: string) {
     const cookieSecure = this.configService.get("COOKIE_SECURE") === "true"; // env파일 별 분기 string -> boolean 변환이요!
+    const cookieDomain = this.configService.get("COOKIE_DOMAIN");
+
     res.cookie("refresh_token", refresh_token, {
       httpOnly: cookieSecure,
       secure: cookieSecure,
+      domain: cookieDomain,
+      sameSite: "none",
       maxAge: 1000 * 60 * 60 * 24 * 7,
     });
 


### PR DESCRIPTION
## 변경내용
직전 배포수준에서 테스트해본 결과 refresh_token이 응답에 담겨왔으나, 저장은 하지 못한 모습을 확인했습니다.

환경은 SSL이 적용된 https 서버<->클라 간의 배포수준 통신입니다.
![](https://velog.velcdn.com/images/he1256/post/4cb73178-5f94-4b2d-98a9-e83c728c1502/image.png)

---

 
해결을 위해, 제가 ai-ght 개인 프로젝트를 하며 서로 다른 도메인 간 어떻게 쿠키를 주고받을 지 고민했던 내용을 반영합니다.


1. `samesite: none` 설정 추가 <- 이는 보안을 위해 반드시 secure 설정과 함께 사용되어야 합니다. (개발환경 제외)
2. `domain 설정` 추가, 이는 환경변수를 통해 받아옵니다. dev는 localhost, prod에선 .(ourdomain.com)을 통해 서브도메인 모두를 허용하도록 했습니다.
	- 도메인은 `COOKIE_DOMAIN`이라는 이름의 환경변수로 관리하므로, 배포 인스턴스 서버에 의 환경변수 파일에도 이를 반영했습니다.

```ts

  async setCookieWithRefreshToken(res: any, refresh_token: string) {
    const cookieSecure = this.configService.get("COOKIE_SECURE") === "true"; 
    // env파일 별 분기 string -> boolean 변환이요!
    const cookieDomain = this.configService.get("COOKIE_DOMAIN");

    res.cookie("refresh_token", refresh_token, {
      httpOnly: cookieSecure,
      secure: cookieSecure,
      domain: cookieDomain,
      sameSite: "none",
      maxAge: 1000 * 60 * 60 * 24 * 7,
    });

    return res;
  }
  
  ...
  
  ```

---
### 쿠키 저장 확인

![](https://velog.velcdn.com/images/he1256/post/d9f84699-8884-47f9-91e6-c8d27064bbe1/image.gif)

![](https://velog.velcdn.com/images/he1256/post/f4fde288-213f-43a7-b994-634d14152bf5/image.png)

![](https://velog.velcdn.com/images/he1256/post/dfc9d153-e5d0-4c14-8e03-18c9d9152d4e/image.png)


