### PR TITLE
dev: feat-auth-jwt : 쿠키 설정에 대한 SameSite 정책 환경 분기 도입 &  refresh token 저장측, AuthGuard 측 hash처리 사용 모듈 구현 및 양측 동일 적용

### DIFF
--- a/nest/package-lock.json
+++ b/nest/package-lock.json
@@ -33,6 +33,7 @@
         "@nestjs/cli": "^9.0.0",
         "@nestjs/schematics": "^9.0.0",
         "@nestjs/testing": "^9.0.0",
+        "@types/bcrypt": "^5.0.0",
         "@types/express": "^4.17.13",
         "@types/jest": "29.5.1",
         "@types/node": "18.16.12",
@@ -1891,6 +1892,15 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.3.0"
+      }
+    },
+    "node_modules/@types/bcrypt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.0.tgz",
+      "integrity": "sha512-agtcFKaruL8TmcvqbndlqHPSJgsolhf/qPWchFlgnW1gECTN/nKbFcoFnvKAQRFfKbh+BO6A3SWdJu9t+xF3Lw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/body-parser": {

--- a/nest/package.json
+++ b/nest/package.json
@@ -44,6 +44,7 @@
     "@nestjs/cli": "^9.0.0",
     "@nestjs/schematics": "^9.0.0",
     "@nestjs/testing": "^9.0.0",
+    "@types/bcrypt": "^5.0.0",
     "@types/express": "^4.17.13",
     "@types/jest": "29.5.1",
     "@types/node": "18.16.12",

--- a/nest/src/UTILS/hash.util.ts
+++ b/nest/src/UTILS/hash.util.ts
@@ -1,0 +1,5 @@
+import * as bcrypt from "bcrypt";
+
+export function hashTokenSync(token: string, saltOrRounds = 10): string {
+  return bcrypt.hashSync(token, saltOrRounds);
+}

--- a/nest/src/auth/auth.guard.ts
+++ b/nest/src/auth/auth.guard.ts
@@ -7,9 +7,10 @@ import {
 import { Observable } from "rxjs";
 import { Reflector } from "@nestjs/core";
 import { JwtService } from "@nestjs/jwt";
-import { IS_PUBLIC_KEY } from "./public.decorator"; // 데코레이터를 가져옵니다.
+import { IS_PUBLIC_KEY } from "./public.decorator";
 import { jwtConstants } from "./constants";
 import { Request } from "express";
+import { hashTokenSync } from "src/UTILS/hash.util";
 
 @Injectable()
 export class AuthGuard implements CanActivate {
@@ -40,7 +41,8 @@ export class AuthGuard implements CanActivate {
       throw new UnauthorizedException("로그인 하세요");
     }
     try {
-      const payload = this.jwtService.verify(token, {
+      const hashedToken = hashTokenSync(token);
+      const payload = this.jwtService.verify(hashedToken, {
         secret: jwtConstants.secret,
       });
       request.user = payload;

--- a/nest/src/auth/auth.service.ts
+++ b/nest/src/auth/auth.service.ts
@@ -55,12 +55,13 @@ export class AuthService {
   async setCookieWithRefreshToken(res: any, refresh_token: string) {
     const cookieSecure = this.configService.get("COOKIE_SECURE") === "true"; // env파일 별 분기 string -> boolean 변환이요!
     const cookieDomain = this.configService.get("COOKIE_DOMAIN");
+    const sameSitePolicy = cookieSecure ? "none" : "lax"; // Secure종속적 Samesite 정책!
 
     res.cookie("refresh_token", refresh_token, {
       httpOnly: cookieSecure,
       secure: cookieSecure,
       domain: cookieDomain,
-      sameSite: "none",
+      sameSite: sameSitePolicy,
       maxAge: 1000 * 60 * 60 * 24 * 7,
     });
 

--- a/nest/src/user/user.service.ts
+++ b/nest/src/user/user.service.ts
@@ -9,6 +9,7 @@ import * as bcrypt from "bcrypt";
 import { User } from "src/user/entities/user.entity";
 import { LoginUserDto } from "./dto/login-user.dto";
 import { RegisterUserDto } from "./dto/register-user.dto";
+import { hashTokenSync } from "src/UTILS/hash.util";
 
 @Injectable()
 export class UserService {
@@ -79,10 +80,8 @@ export class UserService {
   }
 
   async getCurrentHashedRefreshToken(refreshToken: string) {
-    // 토큰 값을 그대로 저장하기 보단, 암호화를 거쳐 데이터베이스에 저장한다.
-    // bcrypt는 단방향 해시 함수이므로 암호화된 값으로 원래 문자열을 유추할 수 없다.
-    const saltOrRounds = 10;
-    const currentRefreshToken = await bcrypt.hash(refreshToken, saltOrRounds);
+    // hashTokenSync 함수를 이용해 token 해싱 후 저장 (비교 시 같은 함수 이용 in AuthGuard, saltOrRound는 양측 모두 default 함수 정의인자 사용)
+    const currentRefreshToken = hashTokenSync(refreshToken);
     return currentRefreshToken;
   }
 


### PR DESCRIPTION
## 1. feat-auth-jwt: 쿠키 설정에 대한 SameSite 정책 환경 분기 도입

로컬 개발 환경에서 refresh token을 수신하는 데 문제를 확인했습니다. 구글의 보안 표준에 따르면, SameSite가 'None'으로 설정되면 Secure 또한 'true'로 설정되어야 합니다. 

직전 반영된 commit인 쿠키 Set 관련 작업에 의해, 개발 환경에서는 조건부로 Secure가 'false'로 설정되는데 SameSite가 static하게 'None'을 설정되었기에 문제였습니다.      

 - 따라서 환경에 따라 결정되는 Secure 환경변수에 의존적으로 SameSite 정책을 결정하는 조건을 도입했습니다. 따라서, Secure가 'false'인 개발환경에서는 SameSite가 'None'이 아니라 'Lax'로 설정됩니다.
 - 이 업데이트는 관련 서비스 파일 내의 setCookieWithRefreshToken 함수에 반영되었어요!
    
## 2. feat-auth-jwt: refresh token 저장측, AuthGuard 측 hash처리 사용 모듈 구현 및 양측 동일 적용

로그아웃이 유효하지 않은 토큰 에러로 처리되지 않는 문제를 확인,

이는 AuthGuard 내 token 유효성 검증 로직에서, refresh token을 user에 저장할 당시 수행한 hash화 로직을 클라이언트를 통해 refresh를 받아 처리하는 검증 측 로직에 동일하게 적용하지 않았기 때문에 발생한 문제로,

이것의 해결을 위해 refresh token을 해싱하는 함수를 모듈화하여 양측에 동일하게(default saltOrRound)를 적용하여 사용하도록 처리하였다.