### PR TITLE
Dev: feat-auth-jwt: AuthGuard 토큰 검증에서 해시화 함수 제거 & logout에 대해 토큰 검증 미이행 처리

### DIFF
--- a/nest/src/auth/auth.controller.ts
+++ b/nest/src/auth/auth.controller.ts
@@ -31,7 +31,6 @@ export class AuthController {
     description: "jwt를 돌려줍니다",
   })
   async login(@Body() loginUserDto: LoginUserDto, @Res() res: Response) {
-    console.log("????");
     const { access_token, refresh_token, nickname, id } =
       await this.authService.login(loginUserDto);
 
@@ -40,6 +39,7 @@ export class AuthController {
     return res.send({ access_token: access_token, nickname: nickname, id: id });
   }
 
+  @Public()
   @Post("logout")
   @ApiOperation({
     summary: "로그아웃",
@@ -51,7 +51,7 @@ export class AuthController {
 
     await this.authService.logout(userId);
 
-    res.clearCookie("refresh_token"); // 쿠키 삭제
+    res.clearCookie("refresh_token"); // http only 쿠키 삭제(서버가 삭제하도록 설정하는것)
 
     return res.sendStatus(200);
   }
@@ -67,6 +67,7 @@ export class AuthController {
     const refresh_token = token.token;
 
     try {
+      // refresh 검증 및 user정보 반환.
       const user = await this.authService.resolveRefreshToken(refresh_token);
       console.log("user", user);
       const newAccessToken = await this.authService.generateAccessToken(user);

--- a/nest/src/auth/auth.guard.ts
+++ b/nest/src/auth/auth.guard.ts
@@ -41,8 +41,8 @@ export class AuthGuard implements CanActivate {
       throw new UnauthorizedException("로그인 하세요");
     }
     try {
-      const hashedToken = hashTokenSync(token);
-      const payload = this.jwtService.verify(hashedToken, {
+      // refresh, access 모두 포함한 후보리스트에 대해 탐색
+      const payload = this.jwtService.verify(token, {
         secret: jwtConstants.secret,
       });
       request.user = payload;


### PR DESCRIPTION
feat-auth-jwt: AuthGuard 토큰 검증에서 해시화 함수 제거 & logout에 대해 토큰 검증 미이행 처리

1. AuthGuard에서 수행하는 token검사는 jwtService에 대한 토큰리스트 탐색으로 hashing하여 userDB에 저장하는 것과 무관하여 이를 수정하였음.

2. 우리 서비스의 경우 로컬 스토리지에 저장된 user-id가 탈취되어 이를 기반으로 타인의 계정에 대한 logout을 수행하는 문제에 대해 큰 보안적 손실이 없다고 판단하여 토큰검증을 미이행합니다.

3. + 로그아웃시 token 블랙리스트 처리에 대해 고민하였으나, 조사해본 결과 블랙리스트 처리의 경우 강제 로그아웃 및 탈취된 토큰에 대해 수행하는 것으로 아직은 도입하지 않는 것으로 판단했습니다.