### PR TITLE
Dev: feat-auth: refresh 컨트롤러가 body가 아닌 req-쿠키로 refresh_token을 수신하도록 설정 & resolveRefreshToken 내 encoded 변수명 -> refresh_token 변경

### DIFF
--- a/nest/src/auth/auth.controller.ts
+++ b/nest/src/auth/auth.controller.ts
@@ -62,20 +62,16 @@ export class AuthController {
     summary: "Access Token 갱신",
     description: "새로운 Access Token을 반환합니다",
   })
-  async refresh(@Body() token: AuthAccessTokenRefreshDto) {
-    console.log("token", token);
-    const refresh_token = token.token;
+  async refresh(@Req() request: Request) {
+    const refresh_token = request.cookies["refresh_token"];
 
     try {
       // refresh 검증 및 user정보 반환.
       const user = await this.authService.resolveRefreshToken(refresh_token);
-      console.log("user", user);
       const newAccessToken = await this.authService.generateAccessToken(user);
-      console.log("generateAccessToken", newAccessToken);
 
       return newAccessToken;
     } catch (e: any) {
-      console.log("e: ", e);
       throw new UnauthorizedException("Access Token 발급 실패");
     }
   }

--- a/nest/src/auth/auth.service.ts
+++ b/nest/src/auth/auth.service.ts
@@ -69,15 +69,15 @@ export class AuthService {
   }
 
   // Refresh token 확인 함수
-  async resolveRefreshToken(encoded) {
-    console.log("encoded", encoded);
-    const payload = await this.jwtService.verifyAsync(encoded.toString(), {
+  async resolveRefreshToken(refreshToken: string) {
+    console.log("refreshToken", refreshToken);
+    const payload = await this.jwtService.verifyAsync(refreshToken.toString(), {
       secret: jwtConstants.secret,
     });
 
     console.log("malformed error payload", payload);
     const tokenExists = await this.userService.getUserIfRefreshTokenMatches(
-      encoded.toString(),
+      refreshToken.toString(),
       payload.sub
     );
 


### PR DESCRIPTION
feat-auth: refresh 컨트롤러가 body가 아닌 req-쿠키로 refresh_token을 수신하도록 설정 & resolveRefreshToken 내 encoded 변수명 -> refresh_token 변경

1. 배포환경에서 클라이언트는 httpOnly,secure 설정의 쿠키에 직접 접근,제어할 수 없으므로 withCredentials를 통해 요청에 쿠키를 자동으로 담아 보내는 방법밖에 사용할 수 없습니다. 따라서 서버도 해당 컨트롤러에서 req의 cookie를 통해서 수신하도록 변경해줬습니다

2. encoded 변수명의 모호함으로 refresh_token으로 수정했습니다.