### PR TITLE
feat-chat-folder: folder entity 구체화 & folder service : [createFolder, createDefaultFolder] 구현 및 등록 (+ user,chatpost 부수작업)

### DIFF
--- a/nest/src/chatposts/chatposts.module.ts
+++ b/nest/src/chatposts/chatposts.module.ts
@@ -6,13 +6,14 @@ import { Chatpost } from "./entities/chatpost.entity";
 import { ChatPairsModule } from "src/chat-pairs/chat-pairs.module";
 import { UserModule } from "src/user/user.module";
 import { CommentsModule } from "src/comments/comments.module";
+import { FoldersModule } from "src/folders/folders.module";
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Chatpost]),
     ChatPairsModule,
     UserModule,
-    // CommentsModule,
+    FoldersModule,
   ],
   controllers: [ChatpostsController],
   providers: [ChatpostsService],

--- a/nest/src/chatposts/chatposts.service.ts
+++ b/nest/src/chatposts/chatposts.service.ts
@@ -6,13 +6,15 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { Chatpost } from "./entities/chatpost.entity";
 import { UserService } from "src/user/user.service";
 import { User } from "src/user/entities/user.entity";
+import { FoldersService } from "src/folders/folders.service";
 
 @Injectable()
 export class ChatpostsService {
   constructor(
     @InjectRepository(Chatpost)
     private chatpostRepository: Repository<Chatpost>,
-    private usersService: UserService
+    private usersService: UserService,
+    private foldersService: FoldersService
   ) {}
 
   async create(createChatpostDto: CreateChatpostDto, user: User) {
@@ -20,7 +22,7 @@ export class ChatpostsService {
       userId: user,
       createdAt: new Date(),
       delYn: "N",
-      folder: null,
+      folder: await this.foldersService.findZeroOrderFolder(user),
       title: createChatpostDto.title,
     };
 

--- a/nest/src/chatposts/entities/chatpost.entity.ts
+++ b/nest/src/chatposts/entities/chatpost.entity.ts
@@ -44,6 +44,9 @@ export class Chatpost {
   @ManyToOne(() => Folder, (folder) => folder.chatposts, { nullable: true })
   folder: Folder;
 
+  @Column()
+  order: number;
+
   @OneToMany(() => ChatPair, (chatPair) => chatPair.chatPost)
   @JoinColumn({ name: "chatPairId" })
   chatPair: ChatPair[];

--- a/nest/src/folders/dto/create-folder.dto.ts
+++ b/nest/src/folders/dto/create-folder.dto.ts
@@ -1,1 +1,11 @@
-export class CreateFolderDto {}
+import { ApiProperty } from "@nestjs/swagger";
+import { IsOptional } from "class-validator";
+import { CreateChatpostDto } from "src/chatposts/dto/create-chatpost.dto";
+
+export class CreateFolderDto {
+  @ApiProperty()
+  folderName: string;
+
+  @ApiProperty()
+  userId: string;
+}

--- a/nest/src/folders/dto/update-folder.dto.ts
+++ b/nest/src/folders/dto/update-folder.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/swagger';
-import { CreateFolderDto } from './create-folder.dto';
+import { PartialType } from "@nestjs/swagger";
+import { CreateFolderDto } from "./create-folder.dto";
 
 export class UpdateFolderDto extends PartialType(CreateFolderDto) {}

--- a/nest/src/folders/entities/folder.entity.ts
+++ b/nest/src/folders/entities/folder.entity.ts
@@ -1,7 +1,9 @@
 import { Chatpost } from "src/chatposts/entities/chatpost.entity";
+import { User } from "src/user/entities/user.entity";
 import {
   Column,
   Entity,
+  JoinColumn,
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
@@ -15,6 +17,15 @@ export class Folder {
   @Column()
   folderName: string;
 
-  @OneToMany(() => Chatpost, (chatpost) => chatpost.chatPostId)
+  @Column()
+  order: number;
+
+  @ManyToOne(() => User, (user) => user.folders)
+  @JoinColumn({ name: "userId" })
+  userId: User;
+
+  @OneToMany(() => Chatpost, (chatpost) => chatpost.chatPostId, {
+    nullable: true,
+  })
   chatposts: Chatpost[];
 }

--- a/nest/src/folders/folders.controller.spec.ts
+++ b/nest/src/folders/folders.controller.spec.ts
@@ -1,8 +1,8 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { FoldersController } from './folders.controller';
-import { FoldersService } from './folders.service';
+import { Test, TestingModule } from "@nestjs/testing";
+import { FoldersController } from "./folders.controller";
+import { FoldersService } from "./folders.service";
 
-describe('FoldersController', () => {
+describe("FoldersController", () => {
   let controller: FoldersController;
 
   beforeEach(async () => {
@@ -14,7 +14,7 @@ describe('FoldersController', () => {
     controller = module.get<FoldersController>(FoldersController);
   });
 
-  it('should be defined', () => {
+  it("should be defined", () => {
     expect(controller).toBeDefined();
   });
 });

--- a/nest/src/folders/folders.controller.ts
+++ b/nest/src/folders/folders.controller.ts
@@ -6,20 +6,28 @@ import {
   Patch,
   Param,
   Delete,
+  Req,
+  UnauthorizedException,
 } from "@nestjs/common";
 import { FoldersService } from "./folders.service";
 import { CreateFolderDto } from "./dto/create-folder.dto";
 import { UpdateFolderDto } from "./dto/update-folder.dto";
-import { ApiTags } from "@nestjs/swagger";
+import { ApiBearerAuth, ApiTags } from "@nestjs/swagger";
 
+@ApiBearerAuth("jwt")
 @ApiTags("folders")
 @Controller("folders")
 export class FoldersController {
   constructor(private readonly foldersService: FoldersService) {}
 
   @Post()
-  create(@Body() createFolderDto: CreateFolderDto) {
-    return this.foldersService.create(createFolderDto);
+  create(@Body() createFolderDto: CreateFolderDto, @Req() req) {
+    console.log("folder controller - createFolder", createFolderDto);
+    if (req.user.id !== createFolderDto.userId) {
+      throw new UnauthorizedException("user is not matched");
+    }
+
+    return this.foldersService.createFolder(createFolderDto);
   }
 
   @Get()

--- a/nest/src/folders/folders.module.ts
+++ b/nest/src/folders/folders.module.ts
@@ -1,11 +1,12 @@
-import { Module } from "@nestjs/common";
+import { Module, forwardRef } from "@nestjs/common";
 import { FoldersService } from "./folders.service";
 import { FoldersController } from "./folders.controller";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { Folder } from "./entities/folder.entity";
+import { UserModule } from "src/user/user.module";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Folder])],
+  imports: [TypeOrmModule.forFeature([Folder]), forwardRef(() => UserModule)],
   controllers: [FoldersController],
   providers: [FoldersService],
   exports: [FoldersService],

--- a/nest/src/folders/folders.service.ts
+++ b/nest/src/folders/folders.service.ts
@@ -1,11 +1,70 @@
-import { Injectable } from '@nestjs/common';
-import { CreateFolderDto } from './dto/create-folder.dto';
-import { UpdateFolderDto } from './dto/update-folder.dto';
+import {
+  Inject,
+  Injectable,
+  NotFoundException,
+  forwardRef,
+} from "@nestjs/common";
+import { CreateFolderDto } from "./dto/create-folder.dto";
+import { UpdateFolderDto } from "./dto/update-folder.dto";
+import { Folder } from "./entities/folder.entity";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { User } from "src/user/entities/user.entity";
+import { UserService } from "src/user/user.service";
 
 @Injectable()
 export class FoldersService {
-  create(createFolderDto: CreateFolderDto) {
-    return 'This action adds a new folder';
+  constructor(
+    @InjectRepository(Folder)
+    private folderRepository: Repository<Folder>,
+    @Inject(forwardRef(() => UserService))
+    private usersService: UserService
+  ) {}
+
+  // user register 전용 무소속 폴더 생성
+  async createDefaultFolder(user: User): Promise<Folder> {
+    const newFolder = this.folderRepository.create({
+      folderName: "무소속",
+      userId: user,
+      order: 0,
+    });
+    await this.folderRepository.save(newFolder);
+    return newFolder;
+  }
+
+  async createFolder(createFolderDto: CreateFolderDto): Promise<Folder> {
+    const { userId, folderName } = createFolderDto;
+
+    // User entity를 찾는다.
+    const ownUser = await this.usersService.findOneById(userId);
+    if (!ownUser) {
+      throw new NotFoundException(`User with id ${userId} not found`);
+    }
+
+    // 해당 folder가 생성되는 user의 folder중 최고 order+1 할당
+    const highestOrderFolder = await this.folderRepository
+      .createQueryBuilder("folder")
+      .where("folder.userId = :userId", { userId: userId })
+      .orderBy("folder.order", "DESC")
+      .getOne(); // 최고order의 Folder get
+
+    // 없으면 0으로 할당, but 원래 0은 없으면 안됨(default 생성 및 보호)
+    const order = highestOrderFolder ? highestOrderFolder.order + 1 : 0;
+
+    const newFolder = this.folderRepository.create({
+      folderName,
+      userId: ownUser,
+      order,
+    });
+    await this.folderRepository.save(newFolder);
+    return newFolder;
+  }
+
+  // chatPost에서 post 생성 시, default folder(무소속 폴더)에 넣기 위해 반환
+  async findZeroOrderFolder(user: User) {
+    return await this.folderRepository.findOne({
+      where: { userId: user, order: 0 },
+    });
   }
 
   findAll() {

--- a/nest/src/user/entities/user.entity.ts
+++ b/nest/src/user/entities/user.entity.ts
@@ -1,6 +1,8 @@
+import { IsOptional } from "class-validator";
 import { Category } from "src/categories/entities/category.entity";
 import { Chatpost } from "src/chatposts/entities/chatpost.entity";
 import { Comment } from "src/comments/entities/comment.entity";
+import { Folder } from "src/folders/entities/folder.entity";
 import { Follow } from "src/follows/entities/follow.entity";
 import { Star } from "src/stars/entities/star.entity";
 import {
@@ -106,4 +108,8 @@ export class User {
   @OneToMany(() => Follow, (follow) => follow.followId)
   @JoinColumn({ name: "followeeId" })
   followeeId: Follow[];
+
+  @OneToMany(() => Folder, (folder) => folder.userId, { nullable: true })
+  @JoinColumn({ name: "folderId" })
+  folders: Folder[];
 }

--- a/nest/src/user/user.module.ts
+++ b/nest/src/user/user.module.ts
@@ -1,10 +1,12 @@
-import { Module } from "@nestjs/common";
+import { Module, forwardRef } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { User } from "src/user/entities/user.entity";
 import { UserService } from "./user.service";
 import { UserController } from "./user.controller";
+import { FoldersModule } from "src/folders/folders.module";
+
 @Module({
-  imports: [TypeOrmModule.forFeature([User])], // User Entity import 확인
+  imports: [TypeOrmModule.forFeature([User]), forwardRef(() => FoldersModule)],
   controllers: [UserController],
   providers: [UserService],
   exports: [UserService],

--- a/nest/src/user/user.service.ts
+++ b/nest/src/user/user.service.ts
@@ -1,7 +1,9 @@
 import {
   BadRequestException,
+  Inject,
   Injectable,
   NotFoundException,
+  forwardRef,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
@@ -10,12 +12,15 @@ import { User } from "src/user/entities/user.entity";
 import { LoginUserDto } from "./dto/login-user.dto";
 import { RegisterUserDto } from "./dto/register-user.dto";
 import { hashTokenSync } from "src/UTILS/hash.util";
+import { FoldersService } from "src/folders/folders.service";
 
 @Injectable()
 export class UserService {
   constructor(
     @InjectRepository(User)
-    private usersRepository: Repository<User>
+    private usersRepository: Repository<User>,
+    @Inject(forwardRef(() => FoldersService))
+    private foldersService: FoldersService
   ) {}
 
   myPage(userId: string) {
@@ -41,9 +46,12 @@ export class UserService {
       provider: null,
       social_id: null,
     };
+    const newUser = await this.usersRepository.save(user);
+
+    const folder = this.foldersService.createDefaultFolder(newUser);
 
     // 사용자 저장 및 반환
-    return this.usersRepository.save(user);
+    return newUser;
   }
 
   // 사용자 증명 검증


### PR DESCRIPTION
## 1. folder 구현을 위한 [folder, user, chatpost] 엔티티 수정
- 1.1. `chatpost`
  - chatpost entity에 order컬럼 추가
  - (+)chatposts.service.ts: create 시, folder 지정을 위해, folder의 findZeroOrderFolder로 탐색한 무소속 폴더(order=0)를 가진 객체 할당하게끔 수정.

- 1.2.  folder의 엔티티 구체화
  - folder는 user에 소속되므로 userId를 FK로 갖는 N:1 관계를 설정.
  - chatPost는 folder에 소속되므로 chatpost와는 1:N관계를 지정. 다만, user생성 시 최초 할당되는 무소속 폴더와 폴더 생성 시를 고려해 nullable.

- 1.3. user 엔티티에 folder 링크. 1:N이다.
 -> 참고) 이번에 수정된 user register는 user Repo에 폴더 생성 이전, 폴더 없이 user를 save한 이후, `createDefaultUser`에 해당 객체를 넣어 folder를 등록하므로, register 중 user 내 folder가 null인 찰나의 시점이 존재하므로, nullable 설정하였음.
  
 -> 참고) 이미 설계 및 사용되는 데이터에 컬럼을 추가하고, CASCADING 극복 및 상호 의존성을 관리하는 등 작업이 필요했기에 TypeORM을 거치지 않고 직접 DATA를 조작하였고, [이로 인한 이슈를 식별 및 해결했습니다. ](https://velog.io/@he1256/Nestjs-TypeORM-%EC%A3%BC%EC%9D%98%EC%A0%90-DB%EC%9D%98-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EC%A7%81%EC%A0%91-%EC%A1%B0%EC%9E%91-%EC%8B%9C-TypeORM%EC%9D%B4-%EC%83%81%ED%83%9C%EB%A5%BC-%EC%B6%94%EC%A0%81%ED%95%98%EC%A7%80-%EB%AA%BB%ED%95%A0-%EC%88%98-%EC%9E%88%EC%9D%8C)
  
<br>

## 2. folder 서비스: `createFolder`, `createDefaultFolder`, `findZeroOrderFolder` 서비스 구현 및 등록, 사용 (+부수작업: DTO설계)

 - 2.1. user.service.ts의 `register` 함수에서 createDefaultFolder를 등록 및 사용 : 이 과정에서 상호참조로 인한 [순환 의존성이 발생 및 해결 (정리글)](https://velog.io/@he1256/ganoverflow0705-nest.js-%EB%AA%A8%EB%93%88-%EC%84%9C%EB%B9%84%EC%8A%A4%EC%9D%98-%EC%88%9C%ED%99%98-%EC%A2%85%EC%86%8D%EC%84%B1-%ED%95%B4%EA%B2%B0-inject-forwardRef)
 
-> 양 측 .module.ts에서 서로의 모듈 import 시 `forwardRef()`를 적용
-> 양 측 .service.ts의 생정자 측에서 `@inject`를 서로의 서비스 임포트 전에 적용

 - 2.2. createFolder 수행 시, 주인 유저가 가진 모든 폴더 중 가장 높은 order+1을 적용하여 최후순위 order할당하도록 설계
 
 - 2.3. findZeroOrderFolder함수는 chatPost에서 새 post 생성(등록) 시, 유저 생성 시 최초유일 발급하는 무소속 폴더(order:0)에 넣기 위해 구현
