### PR TITLE
Feat board : 게시판 기능 구현 완료.

### DIFF
--- a/nest/src/chatposts/chatposts.controller.ts
+++ b/nest/src/chatposts/chatposts.controller.ts
@@ -60,6 +60,12 @@ export class ChatpostsController {
     return this.chatpostsService.findOne(id);
   }
 
+  @Public()
+  @Get("public/:id")
+  publicFindOne(@Param("id") id: string) {
+    return this.chatpostsService.findOne(id);
+  }
+
   @Patch(":id")
   update(
     @Param("id") id: string,

--- a/nest/src/chatposts/chatposts.controller.ts
+++ b/nest/src/chatposts/chatposts.controller.ts
@@ -49,6 +49,12 @@ export class ChatpostsController {
     return this.chatpostsService.findAll();
   }
 
+  @Get("my-chats")
+  async findAllByUserId(@Req() request) {
+    const user = await this.userService.findOneById(request.user.id);
+    return this.chatpostsService.findAllByUserId(user);
+  }
+
   @Get(":id")
   findOne(@Param("id") id: string, @Req() request) {
     return this.chatpostsService.findOne(id);

--- a/nest/src/chatposts/chatposts.service.ts
+++ b/nest/src/chatposts/chatposts.service.ts
@@ -32,10 +32,15 @@ export class ChatpostsService {
     const posts = await this.chatpostRepository.find({
       relations: {
         chatPair: true,
+        userId: true,
       },
     });
     return posts;
     // return `This action returns all chatposts`;
+  }
+
+  async findAllByUserId(user: User) {
+    return this.chatpostRepository.find({ where: { userId: user } });
   }
 
   async findOne(id: string) {

--- a/nest/src/chatposts/chatposts.service.ts
+++ b/nest/src/chatposts/chatposts.service.ts
@@ -50,6 +50,7 @@ export class ChatpostsService {
       relations: {
         chatPair: true,
         comments: true,
+        userId: true,
       },
     });
   }

--- a/nest/src/comments/comments.controller.ts
+++ b/nest/src/comments/comments.controller.ts
@@ -6,6 +6,7 @@ import {
   Patch,
   Param,
   Delete,
+  Req,
 } from "@nestjs/common";
 import { CommentsService } from "./comments.service";
 import { CreateCommentDto } from "./dto/create-comment.dto";
@@ -30,14 +31,14 @@ export class CommentsController {
   })
   @Post("/:chatPostId")
   async create(
-    @Param()
+    @Param("chatPostId")
     chatPostId: string,
-    @Body() createCommentDto: CreateCommentDto
+    @Body() createCommentDto: CreateCommentDto,
+    @Req() req
   ) {
+    // console.log("commentController - create - chatPostId", chatPostId);
     const chatPost = await this.chatPostsService.findOne(chatPostId);
-    const user = await this.userService.findOneByUsername(
-      createCommentDto.userName
-    );
+    const user = await this.userService.findOneByUsername(req.user.userName);
     return this.commentsService.create(chatPost, user, createCommentDto);
   }
 

--- a/nest/src/comments/comments.controller.ts
+++ b/nest/src/comments/comments.controller.ts
@@ -41,10 +41,10 @@ export class CommentsController {
     return this.commentsService.create(chatPost, user, createCommentDto);
   }
 
-  // @Get()
-  // findAll() {
-  //   return this.commentsService.findCommentsByChatPostId("1");
-  // }
+  @Get("/all/:id")
+  findAll(@Param("id") id: string) {
+    return this.commentsService.findCommentsByChatPostId(id);
+  }
 
   @Get(":id")
   findOne(@Param("id") id: string) {

--- a/nest/src/comments/comments.service.ts
+++ b/nest/src/comments/comments.service.ts
@@ -18,7 +18,7 @@ export class CommentsService {
 
   create(chatPost: Chatpost, user: User, createCommentDto: CreateCommentDto) {
     const commentToSave = {
-      chatPostId: chatPost,
+      chatPost: chatPost,
       ...createCommentDto,
       createdAt: new Date(),
       delYn: "N",

--- a/nest/src/comments/dto/create-comment.dto.ts
+++ b/nest/src/comments/dto/create-comment.dto.ts
@@ -1,12 +1,8 @@
 import { ApiProperty } from "@nestjs/swagger";
+import { IsOptional } from "class-validator";
 
 export class CreateCommentDto {
   @ApiProperty()
-  userName: string;
-
-  @ApiProperty()
-  chatPostId: number;
-
-  @ApiProperty()
+  @IsOptional()
   content: string;
 }


### PR DESCRIPTION
# 게시판 기능 정리 - backEnd
 1. API 분리.
   - 원래는 FE의 "chat" 라우트에서 사이드바에 뿌려줄 게시물들을 상남자식으로 전부 다 가져왔었음.
   - 그쪽에는 My chats만 보여주기 위해서 chatposts.controller.ts에 @Get("my-chats")를 추가했어요. guard가 request headers에서 찾은 user 정보를 이 컨트롤러에서 찾아서 service에 넣어줘요. 
   >  ## 컨트롤러와 서비스의 역할 정리
   > 서비스는 웬만하면 서비스를 import해서 찾아오지 않는 게 좋아요. 항상 controller -> service 일방향으로 데이터가 흘러가야 합니다.  서비스가 서비스를 찾아오면, (ex. user -> comment, comment -> user) 순환 의존성 문제가 생길 수 있습니다. forwardRef로 방지할 수 있는 문제지만, 불가피하게 서비스가 서비스를 상호 참조할때만 사용하는게 좋아요. controller와 service는 모두 클래스라서, 하나의 큰 트리구조를 그린다고 생각하시면 좋을 것 같습니다!
   - service에서는 findAllByUserId를 새로 만들어서, 컨트롤러가 넘겨준 user로 where 절을 태웁니다.

2. FE 기준 "게시판" / "posts" 라우트 관련 API 설명
   - **chatposts controller의 @GET() findAll** : 기존의 상남자식 findAll입니다. service에 comment 연관관계 추가해놔서 자동으로 comments까지 join 되어 옵니다.
   - **chatposts controller의 @GET("public/:id") publicFindOne** : 게시물 하나 클릭했을 때 사용합니다.

3. comments
   - GET 요청은 만들어져 있긴 한데.. 사실 chatposts 에서 연관관계로 join돼오는 거라 쓸 일은 없을 것 같습니다.
   - POST 요청은 보시는대로입니다. 위에서 언급했듯, 컨트롤러에서 user를 찾아서 서비스에 넘겨줘요.