### PR TITLE
feat-chat-folder: put folders 컨트롤러 및 서비스 & chatpost용 folders 서비스 구현

### DIFF
--- a/nest/src/chatposts/chatposts.module.ts
+++ b/nest/src/chatposts/chatposts.module.ts
@@ -7,16 +7,12 @@ import { ChatPairsModule } from "src/chat-pairs/chat-pairs.module";
 import { User } from "src/user/entities/user.entity";
 import { UserModule } from "src/user/user.module";
 import { CommentsModule } from "src/comments/comments.module";
-import { FoldersModule } from "src/folders/folders.module";
 import { CategoriesModule } from "src/categories/categories.module";
-
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Chatpost, User]),
     ChatPairsModule,
-    UserModule,
-    FoldersModule,
     CategoriesModule,
     forwardRef(() => UserModule),
   ],

--- a/nest/src/chatposts/chatposts.service.ts
+++ b/nest/src/chatposts/chatposts.service.ts
@@ -5,7 +5,6 @@ import { Repository } from "typeorm";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Chatpost } from "./entities/chatpost.entity";
 import { User } from "src/user/entities/user.entity";
-import { FoldersService } from "src/folders/folders.service";
 import { Category } from "src/categories/entities/category.entity";
 
 @Injectable()
@@ -26,9 +25,7 @@ export class ChatpostsService {
       userId: user,
       createdAt: new Date(),
       delYn: "N",
-      folder: zeroOrderFolder,
       chatpostName: createChatpostDto.chatpostName,
-      order: order,
       categoryName: categoryName,
     };
 
@@ -94,11 +91,12 @@ export class ChatpostsService {
     return post;
   }
 
-  update(id: number, updateChatpostDto: UpdateChatpostDto) {
+  update(id: string, updateChatpostDto: UpdateChatpostDto) {
     return `This action updates a #${id} chatpost`;
   }
 
-  remove(id: number) {
+  async remove(id: Chatpost["chatPostId"]) {
+    this.chatpostRepository.delete(id);
     return `This action removes a #${id} chatpost`;
   }
 }

--- a/nest/src/chatposts/dto/remove-chatpost.dto.ts
+++ b/nest/src/chatposts/dto/remove-chatpost.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsOptional } from "class-validator";
+
+export class RemoveChatpostDto {
+  @ApiProperty()
+  @IsOptional()
+  userId: string;
+}

--- a/nest/src/user/entities/IFolders.ts
+++ b/nest/src/user/entities/IFolders.ts
@@ -1,0 +1,18 @@
+import { Chatpost } from "src/chatposts/entities/chatpost.entity";
+
+export interface IChatpostBasicInfo {
+  chatPostId: Chatpost["chatPostId"];
+  chatpostName: Chatpost["chatpostName"];
+}
+
+export interface IFolderForClient {
+  folderId: number;
+  folderName: string;
+  chatposts: IChatpostBasicInfo[];
+}
+
+export interface IFolder {
+  folderId: number;
+  folderName: string;
+  chatpostIds: Chatpost["chatPostId"][];
+}

--- a/nest/src/user/user.controller.ts
+++ b/nest/src/user/user.controller.ts
@@ -55,7 +55,8 @@ export class UserController {
   @Put("folders/:userId")
   @ApiOperation({
     summary: "사용자의 폴더 & 종속 포스트 정보 갱신",
-    description: "사용자의 폴더 & 종속 포스트 정보를 갱신",
+    description:
+      "사용자의 폴더 & 종속 포스트 정보를 갱신 ( post 소속변경 or 폴더 추가, 제거 시 )",
   })
   async overwriteFoldersWithPosts(
     @Param("userId") userId: string,

--- a/nest/src/user/user.service.ts
+++ b/nest/src/user/user.service.ts
@@ -1,9 +1,7 @@
 import {
   BadRequestException,
-  Inject,
   Injectable,
   NotFoundException,
-  forwardRef,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
@@ -14,6 +12,12 @@ import { RegisterUserDto } from "./dto/register-user.dto";
 import { hashTokenSync } from "src/UTILS/hash.util";
 // import { FoldersService } from "src/folders/folders.service";
 import { ChatpostsService } from "src/chatposts/chatposts.service";
+import { Chatpost } from "src/chatposts/entities/chatpost.entity";
+import {
+  IChatpostBasicInfo,
+  IFolder,
+  IFolderForClient,
+} from "./entities/IFolders";
 @Injectable()
 export class UserService {
   constructor(
@@ -141,32 +145,110 @@ export class UserService {
   //============Folders 관련===========
   // 사용자 폴더 목록 & 매치되는 chatpost기본정보 포함 반환
   async getFoldersWithPosts(user: User) {
-    const folders = JSON.parse(user.folders);
+    const resFolders = JSON.parse(user.folders);
 
-    for (const folder of folders) {
-      folder.chatposts = [];
+    for (const folder of resFolders) {
+      folder.chatposts = [] as IChatpostBasicInfo[]; // chatposts 폴더 초기화
       for (const postId of folder.chatpostIds) {
         // chatpostIds 각각 id에 해당하는 chatpost를 찾아 chatposts 배열에 추가
         const { chatPostId, chatpostName } =
           await this.chatPostsService.findOne(postId);
-        folder.chatposts.push({ chatPostId, chatpostName });
+
+        folder.chatposts.push({
+          chatPostId,
+          chatpostName,
+        } as IChatpostBasicInfo);
       }
+
       // 각 폴더에서 chatpostIds를 삭제
       delete folder.chatpostIds;
     }
-    // 재구조화된 folders 반환
-    return folders;
+
+    // 재구조화된 resFolders 반환
+    return resFolders as IFolderForClient[];
   }
 
-  async overwriteFoldersWithPosts(user: User, folders: any[]): Promise<User> {
-    user.folders = JSON.stringify(
-      folders.map((folder) => ({
-        ...folder,
-        // chatpostIds만 추출하여 배열화 저장
-        chatpostIds: folder.chatposts.map((chatpost) => chatpost.chatPostId),
-      }))
+  // cli에서 드래그앤드롭에 의해 업데이트 & 폴더추가 경우 overwrite하는 용도 (순서, 소속)
+  async overwriteFoldersWithPosts(
+    user: User,
+    folders: IFolderForClient[]
+  ): Promise<IFolderForClient[]> {
+    const newFolders = JSON.stringify(
+      folders.map(
+        (folder) =>
+          ({
+            folderId: folder.folderId,
+            folderName: folder.folderName,
+            chatpostIds: folder.chatposts.map(
+              (chatpost: Chatpost) => chatpost.chatPostId
+            ),
+          } as IFolder)
+      )
+    );
+    user.folders = newFolders;
+    await this.usersRepository.save(user);
+    const restructedFolders = await this.getFoldersWithPosts(user);
+
+    return restructedFolders as IFolderForClient[];
+  }
+
+  // chatpost 서비스에서 chapost 추가 시...
+  async pushChatpostIdToFolder(user: User, chatpost: Chatpost) {
+    const folders = JSON.parse(user.folders);
+    folders[0].chatpostIds.unshift(chatpost.chatPostId);
+    const newFolders = JSON.stringify(folders);
+
+    user.folders = newFolders;
+    await this.usersRepository.save(user);
+  }
+  // chatpost 서비스에서 chatpost 제거 시...
+  async removeChatpostIdFromFolder(user: User, chatpost: Chatpost) {
+    const targetId = chatpost.chatPostId;
+
+    const newFolders = JSON.stringify(
+      JSON.parse(user.folders).map((folder: IFolder) => {
+        folder.chatpostIds = folder.chatpostIds.filter((chatPostId) => {
+          return chatPostId !== targetId;
+        });
+        return folder;
+      })
     );
 
-    return this.usersRepository.save(user);
+    user.folders = newFolders;
+    await this.usersRepository.save(user);
+
+    // 삭제 후, CLI-SERVER 정합성 유지를 위한 반환
+    const restructedFolders = await this.restructFoldersForClient(newFolders);
+
+    return restructedFolders;
+  }
+
+  // push, remove, overwrite의 처리결과를 client와의 정합성 유지를 위해 restruct 및 반환시켜주는 역할
+  async restructFoldersForClient(folders: string) {
+    const parsedFolders = JSON.parse(folders); // IFolder[] => IFolderClient[] 구조변형
+
+    // map은 비동기 함수를 관리하지 못하므로 Promise.all을 사용해 비동기 함수 관리함!
+    const restructedFolders = await Promise.all(
+      parsedFolders.map(async (folder: any) => {
+        folder.chatposts = [] as IChatpostBasicInfo[];
+
+        folder.chatposts = await Promise.all(
+          folder.chatpostIds.map(async (chatPostId: string) => {
+            const { chatpostName } = await this.chatPostsService.findOne(
+              chatPostId
+            );
+
+            return {
+              chatPostId: chatPostId,
+              chatpostName,
+            } as IChatpostBasicInfo;
+          })
+        );
+        delete folder.chatpostIds;
+        return folder;
+      })
+    );
+
+    return restructedFolders as IFolderForClient[];
   }
 }


### PR DESCRIPTION
예정: 정합성 유지를 위한 restructFoldersForClient 함수를 구현하였으나, 불필요한 map^2 처리라고 판단하여, next-nest간 chatposts의 구조를 통일시켜 입출간 처리 제거 예정