### PR TITLE
feat-pagination

### DIFF
--- a/nest/src/chatposts/chatposts.controller.ts
+++ b/nest/src/chatposts/chatposts.controller.ts
@@ -8,6 +8,7 @@ import {
   Delete,
   Req,
   NotFoundException,
+  Query,
 } from "@nestjs/common";
 import { ChatpostsService } from "./chatposts.service";
 import { CreateChatpostDto } from "./dto/create-chatpost.dto";
@@ -124,9 +125,9 @@ export class ChatpostsController {
   }
 
   @Public()
-  @Get()
-  findAll() {
-    return this.chatpostsService.findAll();
+  @Get("")
+  findAll(@Query("page") page: number) {
+    return this.chatpostsService.findAll(page);
   }
 
   @Get("my-chats")

--- a/nest/src/chatposts/chatposts.service.ts
+++ b/nest/src/chatposts/chatposts.service.ts
@@ -44,8 +44,8 @@ export class ChatpostsService {
     return newPostName;
   }
 
-  async findAll() {
-    const posts = await this.chatpostRepository.find({
+  async findAll(page: number) {
+    const [posts, postCount] = await this.chatpostRepository.findAndCount({
       relations: {
         chatPair: true,
         userId: true,
@@ -55,8 +55,11 @@ export class ChatpostsService {
       order: {
         createdAt: "DESC",
       },
+      take: 10,
+      skip: 10 * (page - 1),
     });
-    return posts;
+    // const totalCount = await this.chatpostRepository.count
+    return { posts: posts, postCount: postCount };
     // return `This action returns all chatposts`;
   }
 


### PR DESCRIPTION
# Pagination 기능구현 완료
- Controller에서 query string으로 page를 받습니다.
- `find` 함수를 `findAndCount` 메서드로 변경, 두가지 변수에 `[posts, postCount]` 쿼리 결과값을 받습니다.
- `findAndCount` 메서드의 options에 `take`, `skip` 추가했습니다 => SQL로 치면 `limit`, `offset`과 같음
- 리턴값을 객체로 변경 (기존 : posts 걍 돌려줌, 현재 : `{posts:posts, postCount:postCount}`.
- `postCount`가 필요한 이유 : 전체 몇페이지인지 알아야 끝 페이지에서 paging 멈출 수 있음