### PR TITLE
feat-deletePost : chatposts - remove 관련 수정 & 폴더 삭제 관련 removeAllByFolde구현 등

### DIFF
--- a/nest/src/chat-pairs/entities/chat-pair.entity.ts
+++ b/nest/src/chat-pairs/entities/chat-pair.entity.ts
@@ -13,6 +13,8 @@ export class ChatPair {
   @Column()
   order: number;
 
-  @ManyToOne(() => Chatpost, (chatPost) => chatPost.chatPair)
+  @ManyToOne(() => Chatpost, (chatPost) => chatPost.chatPair, {
+    onDelete: "CASCADE",
+  })
   chatPost: Chatpost;
 }

--- a/nest/src/chatposts/chatposts.service.ts
+++ b/nest/src/chatposts/chatposts.service.ts
@@ -72,6 +72,7 @@ export class ChatpostsService {
 
   async findAll(page: number) {
     const [posts, postCount] = await this.chatpostRepository.findAndCount({
+      where: { delYn: "N" },
       relations: {
         chatPair: true,
         userId: true,
@@ -144,12 +145,12 @@ export class ChatpostsService {
   }
 
   async remove(id: Chatpost["chatPostId"]) {
-    this.chatpostRepository.delete(id);
-    return `This action removes a #${id} chatpost`;
+    await this.chatpostRepository.update(id, { delYn: "Y" });
+    return `This action marks a #${id} chatpost as deleted`;
   }
-  
-  async removeManyByIds(ids: Chatpost['chatPostId'][]){
-    this.chatpostRepository.delete(ids);
+
+  async removeManyByIds(ids: Chatpost["chatPostId"][]) {
+    await this.chatpostRepository.update(ids, { delYn: "Y" });
   }
 
   async findChatpostsUserLiked(user) {

--- a/nest/src/chatposts/chatposts.service.ts
+++ b/nest/src/chatposts/chatposts.service.ts
@@ -147,6 +147,10 @@ export class ChatpostsService {
     this.chatpostRepository.delete(id);
     return `This action removes a #${id} chatpost`;
   }
+  
+  async removeManyByIds(ids: Chatpost['chatPostId'][]){
+    this.chatpostRepository.delete(ids);
+  }
 
   async findChatpostsUserLiked(user) {
     const posts = await this.chatpostRepository

--- a/nest/src/chatposts/dto/remove-all-chatpost-byFolderId.dto.ts
+++ b/nest/src/chatposts/dto/remove-all-chatpost-byFolderId.dto.ts
@@ -1,14 +1,9 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsNotEmpty, IsOptional } from "class-validator";
-import { Chatpost } from "../entities/chatpost.entity";
+import { IsNotEmpty } from "class-validator";
 import { User } from "src/user/entities/user.entity";
 import { IFolder } from "src/user/entities/IFolders";
 
-export class UpdateChatpostNameDto {
-  @ApiProperty()
-  @IsOptional()
-  chatpostName: Chatpost["chatpostName"];
-
+export class RemoveAllByFolderIdDto {
   @ApiProperty()
   @IsNotEmpty()
   userId: User["id"];

--- a/nest/src/chatposts/entities/chatpost.entity.ts
+++ b/nest/src/chatposts/entities/chatpost.entity.ts
@@ -46,7 +46,9 @@ export class Chatpost {
   @IsOptional()
   viewCount: number;
 
-  @OneToMany(() => ChatPair, (chatPair) => chatPair.chatPost)
+  @OneToMany(() => ChatPair, (chatPair) => chatPair.chatPost, {
+    onDelete: "CASCADE",
+  })
   chatPair: ChatPair[];
 
   @OneToMany(() => Comment, (comment) => comment.chatPost)

--- a/nest/src/user/user.service.ts
+++ b/nest/src/user/user.service.ts
@@ -150,6 +150,19 @@ export class UserService {
     return resFolders as IFolder[];
   }
 
+  // 폴더 소속 posts의 id 배열 반환
+  async findAllPostIdsByFolderId(user: User, folderId: IFolder["folderId"]) {
+    const folders: IFolder[] = JSON.parse(user.folders);
+
+    const targetFolder = folders.find(
+      (folder: IFolder) => folder.folderId === folderId
+    );
+    const targetFolderChatpostIds = targetFolder.chatposts.map(
+      (post: IChatpostBasicInfo) => post.chatPostId
+    );
+
+    return targetFolderChatpostIds;
+  }
   // cli에서 드래그앤드롭에 의해 업데이트 & 폴더추가 경우 overwrite하는 용도 (순서, 소속)
   async overwriteFoldersWithPosts(
     user: User,
@@ -227,7 +240,20 @@ export class UserService {
         return folder;
       })
     );
+    user.folders = newFolders;
+    await this.usersRepository.save(user);
+    return JSON.parse(newFolders) as IFolder[];
+  }
 
+  async removeFolderWithPosts(
+    user: User,
+    folderId: number
+  ): Promise<IFolder[]> {
+    const newFolders = JSON.stringify(
+      JSON.parse(user.folders).filter((folder: IFolder) => {
+        return folder.folderId !== folderId;
+      })
+    );
     user.folders = newFolders;
     await this.usersRepository.save(user);
     return JSON.parse(newFolders) as IFolder[];


### PR DESCRIPTION
@hongregii 

두 작업 모두, 기존 프론트에서 putFolders에 의해 폴더만 수정하던 것을, 해당 라우터로 요청 보내는 것으로 수정함에 따른 작업입니다! ( 사이드바에 의한 포스트 삭제 & 폴더 삭제 )

<br><br>

### 1. chatposts - remove 관련 수정
- 기존 프론트에서 putFolders에 의해 폴더만 수정하던 것을, 해당 라우터로 요청 보내는 것으로 수정함에 따른 작업

- chatposts.remove 로직이 chatposts.findOne(id)보다 앞에 있어서 논리적 오류가 있던 점 개선

- 기존 chatposts의 remove 라우터 작업 수행 중, chatposts 제거(`await this.chatpostsService.remove(id);`) 시도 중, chatPair 스키마와의 FK 관계로 에러가 발생. -> 양 측 관계 정의에 `onDelete: "CASCADE",` 명시하여 캐스캐이딩 삭제 가능하도록 수정

<br>

### 2. 폴더 삭제를 위한 chatposts - removeAllByFolderId 구현
- `특정 Folder 소속 chatposts 제거 & user.folders에서 폴더 및 하위 포스트 제거` 목적

- FolderId & User 활용하여 `타겟 포스트s 찾아오기`, ` 타겟 포스트s 제거`, `해당 폴더 및 하위포스트 제거` 순서로 실행

- user측 `findAllPostIdsByFolderId`, `removeFolderWithPosts` 구현 및 활용

<br>

### 3. 기타: `update-chat-post-name.dto`에서 일부 필드 Swagger 프로퍼티 설정 누락을 개선

<br>

---

<br>

결과적으로 프론트의 챗-사이드바 에서 `포스트 삭제`/`폴더 삭제` 각각의 핸들러에서 모두 setFolders를 수행하고 이에 따른 sideEffect로 PUT요청을 발동시켜 폴더만 수정하던 기존 로직에서 위에 구현한 각각의 DELETE 라우터로 제거 요청을 보내도록 수정되었습니다. 

이 둘의 라우터는 포스트 삭제 뿐 아니라 user.Folders에 대한 업데이트를 함께 수행하므로, 그 외 모든 페이지에서도 포스트 삭제 관련해서는 해당 라우터를 사용해주시면 되겠습니다!

(참고: 추가 커밋으로 실제 삭제가 아닌 delYn 처리 및 Get은 이를 필터하여 가져오도록 수정)

--- 

fix )

## fix: chatpost 서비스 - 실제 삭제가 아닌 delYn Y처리 & Get에 N만 포함

1. remove & removeManyByIds 실제 삭제가 아닌 delYn Y로 update하도록 수정
2. Get Chatposts 라우터가 사용하는 서비스의 `findAll`함수의 Where절에 delYn: N 조건 필터링