### PR TITLE
Dev: `mypage 좋아요/내가쓴 게시물 api 구현` & `chatposts - remove 관련 수정 & 폴더 삭제 관련 removeAllByFolde구현` 등

### DIFF
--- a/nest/src/app.module.ts
+++ b/nest/src/app.module.ts
@@ -39,6 +39,7 @@ import { ChatPairsModule } from "./chat-pairs/chat-pairs.module";
         database: configService.get("DB_NAME"),
         entities: [__dirname + "/**/*.entity{.ts,.js}"],
         synchronize: true,
+        logging: ["query", "error"],
       }),
     }),
     UserModule,

--- a/nest/src/chat-pairs/chat-pairs.service.ts
+++ b/nest/src/chat-pairs/chat-pairs.service.ts
@@ -7,6 +7,7 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { CreateChatpostDto } from "src/chatposts/dto/create-chatpost.dto";
 import { ChatpostsService } from "src/chatposts/chatposts.service";
 import { Chatpost } from "src/chatposts/entities/chatpost.entity";
+import { PutChatpostDto } from "src/chatposts/dto/put-chatpost.dto";
 
 @Injectable()
 export class ChatPairsService {
@@ -26,6 +27,14 @@ export class ChatPairsService {
       return savedPairs;
     });
     return savedPairs;
+  }
+
+  async removeAllByChatpostId(chatpostId: Chatpost["chatPostId"]) {
+    const removedPairs = await this.chatPairRepository.delete({
+      chatPost: { chatPostId: chatpostId },
+    });
+
+    return removedPairs;
   }
 
   findAll() {

--- a/nest/src/chat-pairs/entities/chat-pair.entity.ts
+++ b/nest/src/chat-pairs/entities/chat-pair.entity.ts
@@ -13,6 +13,8 @@ export class ChatPair {
   @Column()
   order: number;
 
-  @ManyToOne(() => Chatpost, (chatPost) => chatPost.chatPair)
+  @ManyToOne(() => Chatpost, (chatPost) => chatPost.chatPair, {
+    onDelete: "CASCADE",
+  })
   chatPost: Chatpost;
 }

--- a/nest/src/chatposts/chatposts.controller.ts
+++ b/nest/src/chatposts/chatposts.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Get,
+  Put,
   Post,
   Body,
   Patch,
@@ -23,6 +24,7 @@ import { CategoriesService } from "src/categories/categories.service";
 import { RemoveChatpostDto } from "./dto/remove-chatpost.dto";
 
 import { UpdateChatpostNameDto } from "./dto/update-chatpost-name.dto";
+import { PutChatpostDto } from "./dto/put-chatpost.dto";
 
 @ApiBearerAuth("jwt")
 @ApiTags("chatposts")
@@ -64,6 +66,48 @@ export class ChatpostsController {
     const updatedFolders = await this.userService.pushChatpostIdToFolder(
       user,
       chatPost
+    );
+    console.log("updatedFolders!!!!", updatedFolders);
+    return updatedFolders; // foldersWithChatposts 정합성 위해 반환
+  }
+
+  @Put(":id")
+  @ApiOperation({
+    summary: "chatpost 해당 리소스 오버라이드",
+    description: "chatpost name 업데이트",
+  })
+  async putOneById(
+    @Param("id") id: string,
+    @Body() putChatpostDto: PutChatpostDto,
+    @Req() req
+  ) {
+    const user = await this.userService.findOneByUsername(req.user.username);
+
+    // ^ category 먼저 찾아야함.
+    const categoryName = await this.categoriesService.findOne(
+      putChatpostDto.categoryName
+    );
+
+    // ^ chatPost 수정
+    const chatPost = await this.chatpostsService.put(
+      id,
+      putChatpostDto,
+      user,
+      categoryName
+    );
+
+    //  ^ chatPair 삭제
+    await this.chatpairsService.removeAllByChatpostId(id);
+
+    // ^ 해당 챗포스트 관련 챗페어 새로 등록
+    await this.chatpairsService.create(putChatpostDto, chatPost);
+
+    // ^ chatPost 수정 시, 해당 user의 folders에 업데이트
+    const updatedFolders = await this.userService.updateChatpostNameWithFolders(
+      user,
+      chatPost,
+      putChatpostDto.folderId,
+      putChatpostDto.chatpostName
     );
 
     return updatedFolders; // foldersWithChatposts 정합성 위해 반환

--- a/nest/src/chatposts/chatposts.service.ts
+++ b/nest/src/chatposts/chatposts.service.ts
@@ -51,6 +51,7 @@ export class ChatpostsService {
         userId: true,
         comments: true,
         stars: true,
+        categoryName: true,
       },
       order: {
         createdAt: "DESC",

--- a/nest/src/chatposts/chatposts.service.ts
+++ b/nest/src/chatposts/chatposts.service.ts
@@ -100,6 +100,7 @@ export class ChatpostsService {
         comments: { user: true },
         userId: true,
         stars: true,
+        categoryName: true,
       },
     });
 

--- a/nest/src/chatposts/chatposts.service.ts
+++ b/nest/src/chatposts/chatposts.service.ts
@@ -89,7 +89,23 @@ export class ChatpostsService {
   }
 
   async findAllByUserId(user: User) {
+    console.log(
+      "🚀 ~ file: chatposts.service.ts:92 ~ ChatpostsService ~ findAllByUserId ~ user:",
+      user
+    );
     return this.chatpostRepository.find({ where: { userId: user } });
+  }
+
+  async findMyPosts(user: User) {
+    const posts = await this.chatpostRepository.find({
+      // where: { userId: user },
+      take: 10,
+    });
+    console.log(
+      "🚀 ~ file: chatposts.service.ts:104 ~ ChatpostsService ~ findMyPosts ~ posts:",
+      posts
+    );
+    return posts;
   }
 
   async findOneWithCount(id: string) {
@@ -130,5 +146,20 @@ export class ChatpostsService {
   async remove(id: Chatpost["chatPostId"]) {
     this.chatpostRepository.delete(id);
     return `This action removes a #${id} chatpost`;
+  }
+
+  async findChatpostsUserLiked(user) {
+    const posts = await this.chatpostRepository
+      .createQueryBuilder("chatpost")
+      .leftJoinAndSelect("chatpost.stars", "star")
+      .where("star.user = :userId", { userId: user.id })
+      .andWhere("star.value = :value", { value: "1" })
+      .take(10)
+      .getMany();
+    console.log(
+      "🚀 ~ file: chatposts.service.ts:157 ~ ChatpostsService ~ findChatpostsUserLiked ~ posts:",
+      posts
+    );
+    return posts;
   }
 }

--- a/nest/src/chatposts/chatposts.service.ts
+++ b/nest/src/chatposts/chatposts.service.ts
@@ -72,6 +72,7 @@ export class ChatpostsService {
 
   async findAll(page: number) {
     const [posts, postCount] = await this.chatpostRepository.findAndCount({
+      where: { delYn: "N" },
       relations: {
         chatPair: true,
         userId: true,
@@ -144,8 +145,12 @@ export class ChatpostsService {
   }
 
   async remove(id: Chatpost["chatPostId"]) {
-    this.chatpostRepository.delete(id);
-    return `This action removes a #${id} chatpost`;
+    await this.chatpostRepository.update(id, { delYn: "Y" });
+    return `This action marks a #${id} chatpost as deleted`;
+  }
+
+  async removeManyByIds(ids: Chatpost["chatPostId"][]) {
+    await this.chatpostRepository.update(ids, { delYn: "Y" });
   }
 
   async findChatpostsUserLiked(user) {

--- a/nest/src/chatposts/dto/put-chatpost.dto.ts
+++ b/nest/src/chatposts/dto/put-chatpost.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsOptional } from "class-validator";
+import { CreateChatpostDto } from "./create-chatpost.dto";
+
+export class PutChatpostDto extends CreateChatpostDto {
+  @ApiProperty()
+  @IsOptional()
+  folderId: number;
+}

--- a/nest/src/chatposts/dto/remove-all-chatpost-byFolderId.dto.ts
+++ b/nest/src/chatposts/dto/remove-all-chatpost-byFolderId.dto.ts
@@ -1,14 +1,9 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsNotEmpty, IsOptional } from "class-validator";
-import { Chatpost } from "../entities/chatpost.entity";
+import { IsNotEmpty } from "class-validator";
 import { User } from "src/user/entities/user.entity";
 import { IFolder } from "src/user/entities/IFolders";
 
-export class UpdateChatpostNameDto {
-  @ApiProperty()
-  @IsOptional()
-  chatpostName: Chatpost["chatpostName"];
-
+export class RemoveAllByFolderIdDto {
   @ApiProperty()
   @IsNotEmpty()
   userId: User["id"];

--- a/nest/src/chatposts/entities/chatpost.entity.ts
+++ b/nest/src/chatposts/entities/chatpost.entity.ts
@@ -46,7 +46,9 @@ export class Chatpost {
   @IsOptional()
   viewCount: number;
 
-  @OneToMany(() => ChatPair, (chatPair) => chatPair.chatPost)
+  @OneToMany(() => ChatPair, (chatPair) => chatPair.chatPost, {
+    onDelete: "CASCADE",
+  })
   chatPair: ChatPair[];
 
   @OneToMany(() => Comment, (comment) => comment.chatPost)

--- a/nest/src/stars/stars.module.ts
+++ b/nest/src/stars/stars.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { Module, forwardRef } from "@nestjs/common";
 import { StarsService } from "./stars.service";
 import { StarsController } from "./stars.controller";
 import { UserModule } from "src/user/user.module";
@@ -6,10 +6,14 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { Star } from "./entities/star.entity";
 import { ChatpostsModule } from "src/chatposts/chatposts.module";
 
-
 @Module({
-  imports: [TypeOrmModule.forFeature([Star]), UserModule, ChatpostsModule],
+  imports: [
+    TypeOrmModule.forFeature([Star]),
+    ChatpostsModule,
+    forwardRef(() => UserModule),
+  ],
   controllers: [StarsController],
   providers: [StarsService],
+  exports: [StarsService],
 })
 export class StarsModule {}

--- a/nest/src/stars/stars.service.ts
+++ b/nest/src/stars/stars.service.ts
@@ -89,6 +89,14 @@ export class StarsService {
     };
   }
 
+  // async findChatpostsUserLiked(user: User) {
+  //   const posts = await this.starRepository.find({
+  //     where: { user: user },
+  //     relations: { chatPostId: true },
+  //   });
+  //   return posts;
+  // }
+
   update(id: number, updateStarDto: UpdateStarDto) {
     return `This action updates a #${id} star`;
   }

--- a/nest/src/user/user.module.ts
+++ b/nest/src/user/user.module.ts
@@ -1,12 +1,17 @@
-import { Module } from "@nestjs/common";
+import { Module, forwardRef } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { User } from "src/user/entities/user.entity";
 import { UserService } from "./user.service";
 import { UserController } from "./user.controller";
 import { ChatpostsModule } from "src/chatposts/chatposts.module";
+import { StarsModule } from "src/stars/stars.module";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), ChatpostsModule],
+  imports: [
+    TypeOrmModule.forFeature([User]),
+    ChatpostsModule,
+    forwardRef(() => StarsModule),
+  ],
   controllers: [UserController],
   providers: [UserService],
   exports: [UserService],

--- a/nest/src/user/user.service.ts
+++ b/nest/src/user/user.service.ts
@@ -150,6 +150,19 @@ export class UserService {
     return resFolders as IFolder[];
   }
 
+  // 폴더 소속 posts의 id 배열 반환
+  async findAllPostIdsByFolderId(user: User, folderId: IFolder["folderId"]) {
+    const folders: IFolder[] = JSON.parse(user.folders);
+
+    const targetFolder = folders.find(
+      (folder: IFolder) => folder.folderId === folderId
+    );
+    const targetFolderChatpostIds = targetFolder.chatposts.map(
+      (post: IChatpostBasicInfo) => post.chatPostId
+    );
+
+    return targetFolderChatpostIds;
+  }
   // cli에서 드래그앤드롭에 의해 업데이트 & 폴더추가 경우 overwrite하는 용도 (순서, 소속)
   async overwriteFoldersWithPosts(
     user: User,
@@ -227,7 +240,20 @@ export class UserService {
         return folder;
       })
     );
+    user.folders = newFolders;
+    await this.usersRepository.save(user);
+    return JSON.parse(newFolders) as IFolder[];
+  }
 
+  async removeFolderWithPosts(
+    user: User,
+    folderId: number
+  ): Promise<IFolder[]> {
+    const newFolders = JSON.stringify(
+      JSON.parse(user.folders).filter((folder: IFolder) => {
+        return folder.folderId !== folderId;
+      })
+    );
     user.folders = newFolders;
     await this.usersRepository.save(user);
     return JSON.parse(newFolders) as IFolder[];

--- a/nest/src/user/user.service.ts
+++ b/nest/src/user/user.service.ts
@@ -188,6 +188,10 @@ export class UserService {
       return folder as IFolder;
     });
 
+    user.folders = JSON.stringify(newFolders);
+
+    await this.usersRepository.save(user);
+
     return newFolders as IFolder[];
   }
 
@@ -202,6 +206,7 @@ export class UserService {
     const newFolders = JSON.stringify(folders);
     user.folders = newFolders;
     await this.usersRepository.save(user);
+    return JSON.parse(newFolders) as IFolder[];
   }
 
   // chatpost 서비스에서 chatpost 제거 시...

--- a/nest/src/user/user.service.ts
+++ b/nest/src/user/user.service.ts
@@ -18,12 +18,15 @@ import { IChatpostBasicInfo, IFolder } from "./entities/IFolders";
 export class UserService {
   constructor(
     @InjectRepository(User)
-    private usersRepository: Repository<User>,
-    private readonly chatPostsService: ChatpostsService
+    private usersRepository: Repository<User>
   ) {}
 
-  myPage(userId: string) {
-    return `My page of ${userId} `;
+  async mypage(user: User, posts: Chatpost[], favoritePosts: Chatpost[]) {
+    return {
+      hi: `${user.username}`,
+      myPosts: posts,
+      favoritePosts: favoritePosts,
+    };
   }
 
   async findOneById(id: string): Promise<User> {


### PR DESCRIPTION
## feat : mypage 좋아요/내가쓴 게시물 api 구현, logging : #57 
- mypage 좋아요/내가쓴 게시물 api 구현

- logging : app.module.ts에서 TypeOrmModule.forRoot() 메서드에 옵션으로 error, query 추가. 이렇게 하면 Typeorm으로 query 날릴 때 + 에러 떴을때 로그가 나옴! (생쿼리를 볼 수 있다는 뜻).

<br><br>

## feat-deletePost : chatposts - remove 관련 수정 & 폴더 삭제 관련 removeAllByFolde구현 등 : #58 
### 1. chatposts - remove 관련 수정
- 기존 프론트에서 putFolders에 의해 폴더만 수정하던 것을, 해당 라우터로 요청 보내는 것으로 수정함에 따른 작업

- chatposts.remove 로직이 chatposts.findOne(id)보다 앞에 있어서 논리적 오류가 있던 점 개선

- 기존 chatposts의 remove 라우터 작업 수행 중, chatposts 제거(`await this.chatpostsService.remove(id);`) 시도 중, chatPair 스키마와의 FK 관계로 에러가 발생. -> 양 측 관계 정의에 `onDelete: "CASCADE",` 명시하여 캐스캐이딩 삭제 가능하도록 수정

<br>

### 2. 폴더 삭제를 위한 chatposts - removeAllByFolderId 구현
- `특정 Folder 소속 chatposts 제거 & user.folders에서 폴더 및 하위 포스트 제거` 목적

- FolderId & User 활용하여 `타겟 포스트s 찾아오기`, ` 타겟 포스트s 제거`, `해당 폴더 및 하위포스트 제거` 순서로 실행

- user측 `findAllPostIdsByFolderId`, `removeFolderWithPosts` 구현 및 활용

<br>

### 3. 기타: `update-chat-post-name.dto`에서 일부 필드 Swagger 프로퍼티 설정 누락을 개선

<br>

---

<br>

결과적으로 프론트의 챗-사이드바 에서 `포스트 삭제`/`폴더 삭제` 각각의 핸들러에서 모두 setFolders를 수행하고 이에 따른 sideEffect로 PUT요청을 발동시켜 폴더만 수정하던 기존 로직에서 위에 구현한 각각의 DELETE 라우터로 제거 요청을 보내도록 수정되었습니다. 

이 둘의 라우터는 포스트 삭제 뿐 아니라 user.Folders에 대한 업데이트를 함께 수행하므로, 그 외 모든 페이지에서도 포스트 삭제 관련해서는 해당 라우터를 사용해주시면 되겠습니다!

(참고: 추가 커밋으로 실제 삭제가 아닌 delYn 처리 및 Get은 이를 필터하여 가져오도록 수정)

--- 

fix )

## fix: chatpost 서비스 - 실제 삭제가 아닌 delYn Y처리 & Get에 N만 포함

1. remove & removeManyByIds 실제 삭제가 아닌 delYn Y로 update하도록 수정
2. Get Chatposts 라우터가 사용하는 서비스의 `findAll`함수의 Where절에 delYn: N 조건 필터링