### PR TITLE
chore: naver -> oracle 서버 이전에 따른 github action 업데이트

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -37,7 +37,7 @@ jobs:
       - name: SSH Remote Commands
         uses: appleboy/ssh-action@v0.1.10
         with:
-          host: 118.67.134.211
+          host: 158.180.72.83
           command_timeout: 200m
           username: ${{ secrets.SERVER_USERNAME }}
           password: ${{ secrets.SERVER_PASSWORD }}


### PR DESCRIPTION
클라우드 인스턴스 서버 이관 작업 중입니다.

`SERVER_NAME` 및 `SERVER_PASSWORD`에 변경사항이 있으니, 필요 시 문의해주세요!